### PR TITLE
fixed initialValue with no input changes

### DIFF
--- a/lib/prompt_dialog.dart
+++ b/lib/prompt_dialog.dart
@@ -17,23 +17,23 @@ import 'package:flutter/material.dart';
 /// The `textCapitalization` argument will be textCapitalization text field form of alert dialog.
 ///
 /// Returns a [Future<String?>].
-Future<String?> prompt(
+Future<String> prompt(
   BuildContext context, {
-  Widget? title,
-  Widget? textOK,
-  Widget? textCancel,
-  String? initialValue,
-  String? hintText,
+  Widget title,
+  Widget textOK,
+  Widget textCancel,
+  String initialValue,
+  String hintText,
   int minLines = 1,
   int maxLines = 1,
   bool autoFocus: false,
-  TextInputType? keyboardType,
-  TextInputAction? textInputAction,
+  TextInputType keyboardType,
+  TextInputAction textInputAction,
   bool obscureText: false,
   String obscuringCharacter: '•',
   TextCapitalization textCapitalization = TextCapitalization.none,
 }) {
-  String? value;
+  String value = initialValue;
   return showDialog(
     context: context,
     builder: (_) => WillPopScope(
@@ -47,7 +47,9 @@ Future<String?> prompt(
           keyboardType: keyboardType,
           textInputAction: textInputAction,
           initialValue: initialValue,
-          onChanged: (text) => value = text,
+          onChanged: (text) => {
+            value = text
+          },
           obscureText: obscureText,
           obscuringCharacter: obscuringCharacter,
           textCapitalization: textCapitalization,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 homepage: https://github.com/gtgalone/prompt_dialog
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
If I don't edit anything, but I've set `initialValue` the return value should be updated, otherwise it would be null and then the Navigator will throw.